### PR TITLE
[codex] cache profile analyses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6"
@@ -4706,6 +4707,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -9588,6 +9598,19 @@
     "node_modules/svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
       "license": "ISC"
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/tabbable": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
+    "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/src/app/[username]/ProfileClient.tsx
+++ b/src/app/[username]/ProfileClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import useSWR from "swr";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { PDFExportButton } from "@/components/PDFExportButton";
@@ -18,6 +19,10 @@ import {
 } from "lucide-react";
 import { AnalysisResult } from "@/types";
 import { fetchAuthIdentity } from "@/lib/client-auth";
+import {
+  fetchProfileAnalysis,
+  ProfileAnalysisError,
+} from "@/lib/profile-analysis";
 
 const StatsDashboard = dynamic(
   () =>
@@ -37,35 +42,66 @@ interface ProfileClientProps {
 
 export function ProfileClient({ username, initialData }: ProfileClientProps) {
   const router = useRouter();
-  const [data, setData] = useState<AnalysisResult | null>(initialData || null);
   const [error, setError] = useState<string | null>(null);
   const [showStarModal, setShowStarModal] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
   const [isVerifyingAgain, setIsVerifyingAgain] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const safeUsername = (username || "").toLowerCase();
+  const isInvalidUsername =
+    !username || safeUsername === "undefined" || safeUsername === "null";
 
-  const fetchData = useCallback(
-    async (force = false, nosave = false) => {
-      try {
-        setIsRefreshing(force);
-        const baseUrl = `/api/analyze?username=${username}`;
-        const res = await fetch(
-          `${baseUrl}${force ? "&force=true" : ""}${nosave ? "&nosave=true" : ""}`,
-        );
-        const result = await res.json();
+  const { data, error: fetchError, mutate } = useSWR(
+    isInvalidUsername ? null : ["profile-analysis", username],
+    ([, activeUsername]) => fetchProfileAnalysis(activeUsername),
+    {
+      fallbackData: initialData,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 5 * 60 * 1000,
+      keepPreviousData: true,
+    },
+  );
 
-        if (res.status === 403 && result.error === "Star required") {
-          setShowStarModal(true);
-          return;
-        }
-
-        if (!res.ok) {
-          setError(result.error || "Diagnostic matrix failed");
-          return;
-        }
-
-        setData(result);
+  useEffect(() => {
+    if (fetchError) {
+      if (
+        fetchError instanceof ProfileAnalysisError &&
+        fetchError.code === "STAR_REQUIRED"
+      ) {
+        setShowStarModal(true);
         setError(null);
+        return;
+      }
+
+      setShowStarModal(false);
+      setError(
+        fetchError instanceof Error
+          ? fetchError.message
+          : "Diagnostic matrix failed",
+      );
+      return;
+    }
+
+    if (!isInvalidUsername) {
+      setError(null);
+    }
+  }, [fetchError, isInvalidUsername]);
+
+  useEffect(() => {
+    if (data) {
+      setShowStarModal(false);
+    }
+  }, [data]);
+
+  const refreshAnalysis = useCallback(
+    async (options: { force?: boolean; nosave?: boolean } = {}) => {
+      setIsRefreshing(true);
+
+      try {
+        const nextData = await fetchProfileAnalysis(username, options);
+        await mutate(nextData, { revalidate: false });
 
         const confetti = (await import("canvas-confetti")).default;
         confetti({
@@ -74,18 +110,30 @@ export function ProfileClient({ username, initialData }: ProfileClientProps) {
           origin: { y: 0.6 },
           colors: ["#FFE600", "#FF00E5", "#00F0FF", "#000000"],
         });
-      } catch {
-        setError("NETWORK_FAILURE");
+      } catch (refreshError) {
+        if (
+          refreshError instanceof ProfileAnalysisError &&
+          refreshError.code === "STAR_REQUIRED"
+        ) {
+          setShowStarModal(true);
+          setError(null);
+        } else {
+          setShowStarModal(false);
+          setError(
+            refreshError instanceof Error
+              ? refreshError.message
+              : "NETWORK_FAILURE",
+          );
+        }
       } finally {
         setIsRefreshing(false);
       }
     },
-    [username],
+    [mutate, username],
   );
 
   useEffect(() => {
-    const safeUsername = (username || "").toLowerCase();
-    if (!username || safeUsername === "undefined" || safeUsername === "null") {
+    if (isInvalidUsername) {
       setError("INVALID_ID_SPEC");
       return;
     }
@@ -97,17 +145,13 @@ export function ProfileClient({ username, initialData }: ProfileClientProps) {
       .catch(() => {
         setIsOwner(false);
       });
-
-    if (!initialData) {
-      void fetchData();
-    }
-  }, [username, initialData, fetchData]);
+  }, [isInvalidUsername, safeUsername]);
 
   const handleRecheckStar = async () => {
     setIsVerifyingAgain(true);
     try {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      await fetchData();
+      await refreshAnalysis();
     } finally {
       setIsVerifyingAgain(false);
     }
@@ -231,7 +275,7 @@ export function ProfileClient({ username, initialData }: ProfileClientProps) {
 
         {(data.isLocked || data.isHistorical) && (
           <button
-            onClick={() => fetchData(true, true)}
+            onClick={() => refreshAnalysis({ force: true, nosave: true })}
             disabled={isRefreshing}
             className="neo-button bg-neo-yellow text-[10px] md:text-sm flex items-center justify-center gap-2 group shadow-neo-active hover:shadow-neo transition-all disabled:opacity-50"
           >
@@ -242,7 +286,7 @@ export function ProfileClient({ username, initialData }: ProfileClientProps) {
 
         {(isOwner || (!data.isLocked && !data.isHistorical)) && (
           <button
-            onClick={() => fetchData(true, false)}
+            onClick={() => refreshAnalysis({ force: true })}
             disabled={isRefreshing}
             className="neo-button bg-neo-green text-[10px] md:text-sm flex items-center justify-center gap-2 group shadow-neo-active hover:shadow-neo transition-all disabled:opacity-50"
           >

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -1,0 +1,60 @@
+import type { AnalysisResult } from "@/types";
+
+type ProfileAnalysisOptions = {
+  force?: boolean;
+  nosave?: boolean;
+};
+
+export class ProfileAnalysisError extends Error {
+  status: number;
+  code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.name = "ProfileAnalysisError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const buildProfileUrl = (username: string, options: ProfileAnalysisOptions) => {
+  const params = new URLSearchParams({ username });
+
+  if (options.force) {
+    params.set("force", "true");
+  }
+
+  if (options.nosave) {
+    params.set("nosave", "true");
+  }
+
+  return `/api/analyze?${params.toString()}`;
+};
+
+export async function fetchProfileAnalysis(
+  username: string,
+  options: ProfileAnalysisOptions = {},
+): Promise<AnalysisResult> {
+  const res = await fetch(buildProfileUrl(username, options), {
+    cache: "no-store",
+  });
+  const result = await res.json().catch(() => ({}));
+
+  if (res.status === 403 && result?.error === "Star required") {
+    throw new ProfileAnalysisError(
+      result?.message || "Star required",
+      403,
+      "STAR_REQUIRED",
+    );
+  }
+
+  if (!res.ok) {
+    throw new ProfileAnalysisError(
+      result?.error || result?.message || "Diagnostic matrix failed",
+      res.status,
+      result?.error || "ANALYSIS_FAILED",
+    );
+  }
+
+  return result as AnalysisResult;
+}


### PR DESCRIPTION
## What changed
- Added an SWR-backed fetch layer for profile analyses so repeated navigations reuse cached responses instead of refetching GitHub data every mount.
- Moved the API call into a shared helper that normalizes errors, handles the star-gate response, and supports force refreshes.
- Wired the existing refresh buttons through the cached mutate path so manual refreshes update the same cache entry.

## Why
- This issue calls out repeated GitHub API requests. The profile page was doing a local fetch in the client component on remount, so the same username could trigger the analysis again even when the app already had the result.

## Validation
- npm run lint
- npm run build (passed after supplying the repo's required local environment variables)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced profile analysis fetching with better error handling and messaging
  * More reliable profile refresh and analysis updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->