### PR TITLE
Link Fixes in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Contributions are welcome. Please see [CONTRIBUTING.md](https://github.com/0xarc
 
 ## Security
 
-For security vulnerabilities, see [SECURITY.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file#security-policy).
+For security vulnerabilities, see [SECURITY.md](https://github.com/0xarchit/github-profile-analyzer?tab=security-ov-file#security-policy).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ src/
 
 ## Contributing
 
-Contributions are welcome. Please see [CONTRIBUTING.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file) for guidelines.
+Contributions are welcome. Please see [CONTRIBUTING.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file#contributing-to-github-profile-analyzer) for guidelines.
 
 ## Security
 
-For security vulnerabilities, see [SECURITY.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file).
+For security vulnerabilities, see [SECURITY.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file#security-policy).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -151,15 +151,15 @@ src/
 
 ## Contributing
 
-Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome. Please see [CONTRIBUTING.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file) for guidelines.
 
 ## Security
 
-For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+For security vulnerabilities, see [SECURITY.md](https://github.com/0xarchit/github-profile-analyzer?tab=contributing-ov-file).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License - see [LICENSE](https://github.com/0xarchit/github-profile-analyzer?tab=MIT-1-ov-file) for details.
 
 ## Support
 


### PR DESCRIPTION
## Description

Updated the links for **CONTRIBUTING.md**, **SECURITY.md**, and **LICENSE** in the `README.md` to point to their correct locations.

- **CONTRIBUTING.md** - Fixed a broken link that previously returned a **404**. It now opens the **Contributing** section on the repository homepage, directing users to the first heading in a new tab.
- **SECURITY.md** - Fixed a broken link that previously returned a **404**. It now opens the **Security** section on the repository homepage, directing users to the first heading in a new tab.
- **LICENSE** - Updated the link to open the **License** section on the repository homepage in a new tab.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

Verified that all updated links:
- Open the correct destination.
- Open in a new tab.
- No longer return a **404** for the **Contributing** and **Security** links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README links for Contributing, Security, and License sections to point directly to the relevant GitHub pages and sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->