### PR TITLE
fix: replace broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ src/
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=0xarchit%2Fgithub-profile-analyzer&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#0xarchit/github-profile-analyzer&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=0xarchit/github-profile-analyzer&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=0xarchit/github-profile-analyzer&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=0xarchit/github-profile-analyzer&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=0xarchit/github-profile-analyzer&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=0xarchit/github-profile-analyzer&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=0xarchit/github-profile-analyzer&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart is broken because of GitHub stargazer API restrictions. This PR switches it to a working alternative so the chart renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the new `star-history.dera.page` URLs.
  * Replaced outdated Star History and API endpoint references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->